### PR TITLE
remove initial waiting time

### DIFF
--- a/src/Body.svelte
+++ b/src/Body.svelte
@@ -9,8 +9,8 @@
     import { showPreferences } from "./showPreferences";
     import { fade } from "svelte/transition";
     const modules = [Welcome, CatFetch, Links, Authors, Blog, Dd];
-    let displayModules: any[] = [Welcome];
-    let i: number = 1;
+    let displayModules: any[] = [Welcome, Catfetch];
+    let i: number = 2;
     const s = setInterval(() => {
         if (displayModules.length == modules.length) {
             clearInterval(s);


### PR DESCRIPTION
catfetch being hidden from the start adds waiting time, during which only the welcome message is shown. doing what i did here would start typing out catfetch --meow 